### PR TITLE
Add a simple Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: setup install build start clean rebuild test
+
+setup: install build
+
+install:
+	@echo "\033[1;34m-----> \033[1;39mInstalling dependencies...\033[0m"
+	@bundle install
+
+build:
+	@echo "\033[1;34m-----> \033[1;39mBuilding site...\033[0m"
+	@bundle exec jekyll build
+
+start:
+	@echo "\033[1;34m-----> \033[1;39mStarting server...\033[0m"
+	@bundle exec jekyll serve
+
+clean:
+	@echo "\033[1;34m-----> \033[1;39mCleaning up...\033[0m"
+	@rm -rf .jekyll-metadata
+	@rm -rf .sass-cache
+	@rm -rf _site
+
+rebuild: clean build
+
+test:
+	@echo "\033[1;34m-----> \033[1;39mNo tests yet!\033[0m"

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ $ git clone github.com/crossingscon/crossingscon.org
 $ cd crossingscon.org
 
 # install dependencies
-$ bundle install
+$ make install
 
 # build the site (optional, because you probably just want to...)
-$ bundle exec jekyll build
+$ make build
 
 # use jekyll's server mode
-$ bundle exec jekyll serve
+$ make start
 ```
 
 You should now be able to see the site at [http://localhost:4000/](http://localhost:4000/).


### PR DESCRIPTION
For two reasons:
- It serves as a better place to document build / deploy processes than the README
- It makes the repo slightly more accessible to less-experienced devs
