### PR TITLE
Update location to reflect hyatt buyout/rename

### DIFF
--- a/_static/location.md
+++ b/_static/location.md
@@ -11,9 +11,9 @@ published: true
   <div class="col-12 col-md-6 mb-3"><img src="{{site.baseurl}}/images/hyatt2.jpg"/></div>
 </div>
 
-Our hotel this year is the beautiful [Hyatt Regency Montréal](https://montreal.regency.hyatt.com/en/hotel/home.html), at 1255 Jeanne-Mance, Montréal, Québec, Canada, H5B 1E5.
+Our hotel this year is the beautiful [DoubleTree by Hilton Montreal](https://doubletree3.hilton.com/en/hotels/quebec/doubletree-by-hilton-montreal-YMQDTDT/index.html), at 1255 Jeanne-Mance, Montréal, Québec, Canada, H5B 1E5.
 
-[We have a discounted room block for CrossingsCon attendees](https://book.passkey.com/go/CROSSINGS2019) at the Hyatt Regency from June 20-24, 2019. Rooms are $219 CAD, which is about $170 USD at current rates. The room block will be open until May 30, 2019.
+[We have a discounted room block for CrossingsCon attendees](https://book.passkey.com/go/CROSSINGS2019) at DoubleTree from June 20-24, 2019. Rooms are $219 CAD, which is about $170 USD at current rates. The room block will be open until May 30, 2019.
 
 If you cannot get a room in the room block, please [let us know]({{site.baseurl}}/about/contact)! Space is limited, but we want to try to find a place for everyone who wants to attend, and we will make every effort to get you into the room block or find something nearby.
 


### PR DESCRIPTION
Basically just changes the name Hyatt to DoubleTree, as well as the link to the hotel. Does not yet change the link to the room block, still waiting to hear back from Jill re: the new link.