### PR TITLE
Add functionality to buy merch directly from the base site

### DIFF
--- a/_static/badges/merchandise.md
+++ b/_static/badges/merchandise.md
@@ -5,26 +5,19 @@ order: 40
 published: true
 ---
 
+<script src="{{ site.baseurl | prepend: site.url }}/js/buybutton.js"></script>
+
 ![merch]
 
 While you're buying your badge, why not take the opportunity to get yourself some sweet CrossingsCon swag to go with it?
 
-Merchandise can be pre-ordered [on our online store](https://store.crossingscon.org) and will be available for pickup at CrossingsCon. Prices listed include tax and are in US dollars. All you'll need to pick up your merch is the order number of your order (or orders), all payments for pre-ordered merch will be online.
+Merchandise can be pre-ordered below or [on our online store](https://store.crossingscon.org) and will be available for pickup at CrossingsCon. Prices listed include tax and are in US dollars. All you'll need to pick up your merch is the order number of your order (or orders), all payments for pre-ordered merch will be online.
 
-You can pre-order merch separate from buying your badge. You can even order merch without buying a badge at all, though you'll have to make your own arrangements to have someone pick it up for you. Be aware that while some merchandise will be available for purchase at the convention, not all will be. Pre-ordering is the only way you guarantee you get the merch you want.
+You can pre-order merch separate from buying your badge. You can even order merch without buying a badge at all, though you'll have to make your own arrangements to have someone pick it up for you. Be aware that while some merchandise will be available for purchase at the convention, not all will be. Pre-ordering is the only way you guarantee you get the merch you want. Several other items will be available for pre-order in the near future. If you want to give input on what items you'd like to see, [you can do so here](https://docs.google.com/forms/d/e/1FAIpQLSeUxML2CeXrFn1JAgilMU65OqJlq82PFW9rWmasGgzABvQ8Vg/viewform).
 
 If you have any questions reach out to <info@crossingscon.org> or <merch@crossingscon.org>.
 
-## CrossingsCon 2019 Shirt
 
-Adorn yourself in proof that you made it to CrossingsCon 2019!
-
-<img alt="T-shirt design reading 'CROSSINGSCON 2019 Hello. Bonjour. Dai Stihó' in blue, green and white on a black field with illustrated stars" src="{{ site.baseurl }}/images/merch/shirts/tshirt2019.jpg">
-
-Our shirts come in unisex cut (sizes S&ndash;3XL). They cost $25 USD.
-
-## Other merchandise
-
-Several other items will be available for pre-order on the online store in the near future. If you want to give input on what items you'd like to see, [you can do so here](https://docs.google.com/forms/d/e/1FAIpQLSeUxML2CeXrFn1JAgilMU65OqJlq82PFW9rWmasGgzABvQ8Vg/viewform).
+<div id='collection-component-5160491c5be'></div>
 
 [merch]: {{ site.baseurl }}/images/merch-table.jpg

--- a/js/buybutton.js
+++ b/js/buybutton.js
@@ -1,0 +1,158 @@
+/*<![CDATA[*/
+
+(function () {
+  var scriptURL = 'https://sdks.shopifycdn.com/buy-button/latest/buy-button-storefront.min.js';
+  if (window.ShopifyBuy) {
+    if (window.ShopifyBuy.UI) {
+      ShopifyBuyInit();
+    } else {
+      loadScript();
+    }
+  } else {
+    loadScript();
+  }
+
+  function loadScript() {
+    var script = document.createElement('script');
+    script.async = true;
+    script.src = scriptURL;
+    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(script);
+    script.onload = ShopifyBuyInit;
+  }
+
+  function ShopifyBuyInit() {
+    var client = ShopifyBuy.buildClient({
+      domain: 'crossingscon.myshopify.com',
+      storefrontAccessToken: '4eaef643320d50bb2ac9ac775c79e8b2',
+    });
+
+    ShopifyBuy.UI.onReady(client).then(function (ui) {
+      ui.createComponent('collection', {
+        id: 68863197240,
+        node: document.getElementById('collection-component-5160491c5be'),
+        moneyFormat: '%24%7B%7Bamount%7D%7D',
+        options: {
+          "product": {
+            "buttonDestination": "modal",
+            "variantId": "all",
+            "contents": {
+              "imgWithCarousel": false,
+              "variantTitle": false,
+              "options": false,
+              "description": false,
+              "buttonWithQuantity": false,
+              "quantity": false
+            },
+            "text": {
+              "button": "VIEW PRODUCT"
+            },
+            "styles": {
+              "product": {
+                "@media (min-width: 601px)": {
+                  "max-width": "calc(33.33333% - 30px)",
+                  "margin-left": "30px",
+                  "margin-bottom": "50px",
+                  "width": "calc(33.33333% - 30px)"
+                },
+                "imgWrapper": {
+                  "position": "relative",
+                  "height": "0",
+                  "padding-top": "calc(75% + 15px)"
+                },
+                "img": {
+                  "height": "calc(100% - 15px)",
+                  "position": "absolute",
+                  "left": "0",
+                  "right": "0",
+                  "top": "0"
+                }
+              },
+              "button": {
+                "background-color": "#005bab",
+                ":hover": {
+                  "background-color": "#00529a"
+                },
+                ":focus": {
+                  "background-color": "#00529a"
+                }
+              }
+            }
+          },
+          "cart": {
+            "contents": {
+              "button": true
+            },
+            "text": {
+              "notice": ""
+            },
+            "styles": {
+              "button": {
+                "background-color": "#005bab",
+                ":hover": {
+                  "background-color": "#00529a"
+                },
+                ":focus": {
+                  "background-color": "#00529a"
+                }
+              },
+              "footer": {
+                "background-color": "#ffffff"
+              }
+            }
+          },
+          "modalProduct": {
+            "contents": {
+              "img": false,
+              "imgWithCarousel": true,
+              "variantTitle": false,
+              "buttonWithQuantity": true,
+              "button": false,
+              "quantity": false
+            },
+            "styles": {
+              "product": {
+                "@media (min-width: 601px)": {
+                  "max-width": "100%",
+                  "margin-left": "0px",
+                  "margin-bottom": "0px"
+                }
+              },
+              "button": {
+                "background-color": "#005bab",
+                ":hover": {
+                  "background-color": "#00529a"
+                },
+                ":focus": {
+                  "background-color": "#00529a"
+                }
+              }
+            }
+          },
+          "toggle": {
+            "styles": {
+              "toggle": {
+                "background-color": "#005bab",
+                ":hover": {
+                  "background-color": "#00529a"
+                },
+                ":focus": {
+                  "background-color": "#00529a"
+                }
+              }
+            }
+          },
+          "productSet": {
+            "styles": {
+              "products": {
+                "@media (min-width: 601px)": {
+                  "margin-left": "-30px"
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+  }
+})();
+    /*]]>*/


### PR DESCRIPTION
Adds a script provided by Shopify that allows for buying of merch directly from the main site, without visiting the online store. Interface is customized with theme colours and font.

Asking for review since I'm not sure if this is something we want to add or not.